### PR TITLE
SEO-204554-Ej2-React-Multiple-H1-tag-Hotfix

### DIFF
--- a/ej2-react/pivotview/state-persistence.md
+++ b/ej2-react/pivotview/state-persistence.md
@@ -29,7 +29,7 @@ State persistence allows user to maintain the current state of the component alo
 
  {% previewsample "page.domainurl/code-snippet/pivot-table/default-cs286" %}
 
-# Save and Load Pivot Layout
+## Save and Load Pivot Layout
 
 You can save the current layout of the pivot table by using [`getPersistData`](https://ej2.syncfusion.com/react/documentation/api/pivotview/#getpersistdata) in string format. The saved layout can be loaded to pivot table any time by passing the saved data as a parameter to [`loadPersistData`](https://ej2.syncfusion.com/react/documentation/api/pivotview/#loadpersistdata) method.
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Multiple-H1-tag|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204554|
|Share point| [share point](https://syncfusion-my.sharepoint.com/:x:/p/mallika_kannan/EQqtb1gQd9pEiVkIQmHydnABkMETPelwV42V_5voCRbxgQ?wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1751515828401&web=1)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag I One page should have only one H1 tag as per SEO rules, so I changed it.|


Regards, 
Asha